### PR TITLE
Fix URL Path Issues and Add Helper Class for TOTP and Header Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ below is an example on how to logon to the API and fetch your own user informati
 
 ```typescript
 import axios, { AxiosInstance } from 'axios'; // Header Instance for VRChat
-import * as VRChat from 'vrchat';
+import * as VRChat from 'vrchat';             
 
 const configuation = new VRChat.Configuration({
     username: "username",
@@ -68,8 +68,8 @@ const axiosInstance: AxiosInstance = axios.create({
 
 const AuthenticationApi = new VRChat.AuthenticationApi(configuation, undefined, axiosInstance).verify2FA({code: "otp"}); //Use TOTP to get the code from the Base32
 
-const CurrentUser = await AuthenticationApi.getCurrentUser();
-const currentUser = CurrentUser.data;
+const CurrentUserObject = await AuthenticationApi.getCurrentUser();
+const currentUser = CurrentUserObject.data;
 console.log(`Logged in as: ${currentUser.displayName}`);
 
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ AuthenticationApi.getCurrentUser().then(resp => {
 
 See [example.js](https://github.com/vrchatapi/vrchatapi-javascript/blob/master/example.js) for more example usage on getting started.
 
+
+## Getting Started with TypeScript
+
+below is an example on how to logon to the API and fetch your own user information.
+
+```typescript
+import axios, { AxiosInstance } from 'axios'; // Header Instance for VRChat
+import * as VRChat from 'vrchat';
+
+const configuation = new VRChat.Configuration({
+    username: "username",
+    password: "password"
+});
+
+const axiosInstance: AxiosInstance = axios.create({
+  headers: {
+    'User-Agent': 'Softwarename/1.0.0.0 email@adress'
+  }
+}); 
+
+const AuthenticationApi = new VRChat.AuthenticationApi(configuation, undefined, axiosInstance).verify2FA({code: "otp"}); //Use TOTP to get the code from the Base32
+
+const CurrentUser = await AuthenticationApi.getCurrentUser();
+const currentUser = CurrentUser.data;
+console.log(`Logged in as: ${currentUser.displayName}`);
+
+```
+
 ## Contributing
 
 Contributions are welcome, but do not add features that should be handled by the OpenAPI specification.

--- a/api.ts
+++ b/api.ts
@@ -7297,9 +7297,9 @@ export const AuthenticationApiAxiosParamCreator = function (configuration?: Conf
          * @throws {RequiredError}
          */
         verifyRecoveryCode: async (twoFactorAuthCode: TwoFactorAuthCode, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'twoFactorAuthCode' is not null or undefined
-            assertParamExists('verifyRecoveryCode', 'twoFactorAuthCode', twoFactorAuthCode)
-            const localVarPath = `/auth/twofactorauth/otp/verify`;
+             // verify required parameter 'twoFactorAuthCode' is not null or undefined
+            assertParamExists('verify2FA', 'twoFactorAuthCode', twoFactorAuthCode);
+            const localVarPath = `/auth/twofactorauth/totp/verify`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -7307,20 +7307,21 @@ export const AuthenticationApiAxiosParamCreator = function (configuration?: Conf
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
             // authentication authCookie required
-
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(twoFactorAuthCode, localVarRequestOptions, configuration)
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+
+            // Nest the code within an object
+            localVarRequestOptions.data = {
+                code: serializeDataIfNeeded(twoFactorAuthCode.code, localVarRequestOptions, configuration)
+            };
 
             return {
                 url: toPathString(localVarUrlObj),

--- a/example.js
+++ b/example.js
@@ -1,3 +1,6 @@
+/*
+ * Outdated!
+*/
 const vrchat = require("vrchat");
 const configuration = new vrchat.Configuration({
     username: "username",

--- a/helper.ts
+++ b/helper.ts
@@ -1,0 +1,31 @@
+import { TOTP } from 'totp-generator';
+import axios, { AxiosInstance } from 'axios';
+
+/**
+ * Creates an Axios instance with custom headers.
+ * @summary VRChat API Header
+ * @param {string} customHeader - Custom header for the requests. Format: [name]/1.0.0.0 [email]
+ * @returns {AxiosInstance} - Axios instance with the specified headers
+ */
+export function VRChatHead(customHeader: string): AxiosInstance {
+    const headersInstance: AxiosInstance = axios.create({
+        headers: {
+            'User-Agent': customHeader
+        }
+    });
+
+    return headersInstance;
+}
+
+/**
+ * Generates a TOTP token for 2FA verification.
+ * @param {string} base32 - Base32 string from the TOTP setup.
+ * @returns {{code: string, duration: number}} - Object containing the OTP and its duration
+ */
+export function GenerateTOTP(base32: string): { code: string, duration: number } {
+    const { otp, expires } = TOTP.generate(base32);
+    return {
+        code: otp,
+        duration: expires
+    };
+}

--- a/index.ts
+++ b/index.ts
@@ -14,4 +14,5 @@
 
 export * from "./api";
 export * from "./configuration";
+export * from './helper';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/tough-cookie": "^4.0.1",
-        "axios": "^0.26.1",
+        "axios": "^1.7.2",
         "axios-cookiejar-support": "^1.0.1",
         "tough-cookie": "^4.0.0"
       },
@@ -30,12 +30,21 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
       "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios-cookiejar-support": {
@@ -53,6 +62,27 @@
         "@types/tough-cookie": ">=2.3.3",
         "axios": ">=0.16.2",
         "tough-cookie": ">=2.3.3"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -74,12 +104,47 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/pify": {
@@ -92,6 +157,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -153,12 +224,19 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
       "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "axios-cookiejar-support": {
@@ -170,20 +248,61 @@
         "pify": "^5.0.0"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
     "follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "pify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
       "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "vrchat",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vrchat",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "MIT",
       "dependencies": {
         "@types/tough-cookie": "^4.0.1",
         "axios": "^1.7.2",
         "axios-cookiejar-support": "^1.0.1",
+        "totp-generator": "^1.0.0",
         "tough-cookie": "^4.0.0"
       },
       "devDependencies": {
@@ -126,6 +127,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jssha": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
+      "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -175,6 +185,15 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/totp-generator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/totp-generator/-/totp-generator-1.0.0.tgz",
+      "integrity": "sha512-Iu/1Lk60/MH8FE+5cDWPiGbwKK1hxzSq+KT9oSqhZ1BEczGIKGcN50bP0WMLiIZKRg7t29iWLxw6f81TICQdoA==",
+      "license": "MIT",
+      "dependencies": {
+        "jssha": "^3.3.1"
       }
     },
     "node_modules/tough-cookie": {
@@ -281,6 +300,11 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
+    "jssha": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
+      "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ=="
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -313,6 +337,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "totp-generator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/totp-generator/-/totp-generator-1.0.0.tgz",
+      "integrity": "sha512-Iu/1Lk60/MH8FE+5cDWPiGbwKK1hxzSq+KT9oSqhZ1BEczGIKGcN50bP0WMLiIZKRg7t29iWLxw6f81TICQdoA==",
+      "requires": {
+        "jssha": "^3.3.1"
+      }
     },
     "tough-cookie": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-"tough-cookie": "^4.0.0",
-"axios-cookiejar-support": "^1.0.1",
-"@types/tough-cookie": "^4.0.1",
-    "axios": "^0.26.1"
+    "tough-cookie": "^4.0.0",
+    "axios-cookiejar-support": "^1.0.1",
+    "@types/tough-cookie": "^4.0.1",
+    "axios": "^1.7.2"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vrchat",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "🟡🔵 VRChat API Library for JavaScript and TypeScript",
   "author": "OpenAPI-Generator Contributors",
   "repository": {
@@ -22,10 +22,11 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "tough-cookie": "^4.0.0",
-    "axios-cookiejar-support": "^1.0.1",
     "@types/tough-cookie": "^4.0.1",
-    "axios": "^1.7.2"
+    "axios": "^1.7.2",
+    "axios-cookiejar-support": "^1.0.1",
+    "totp-generator": "^1.0.0",
+    "tough-cookie": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES5",
     "module": "commonjs",
     "noImplicitAny": true,
-    "outDir": "dist",
+    "outDir": "./dist",
     "rootDir": ".",
     "lib": [
       "es6",


### PR DESCRIPTION
I fixed some URL path issues in the `verify2FA` method. The URL path has been changed from OTP to TOTP [see here](https://vrchatapi.github.io/docs/api/#post-/auth/twofactorauth/totp/verify).
Additionally, I added a helper class to generate TOTP codes and create headers.
Updated Axios to `1.7.2` from the old `0.26.1`.
