### PR TITLE
Expose vrchat/websocket export

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./websocket": {
+      "types": "./dist/websocket.d.ts",
+      "import": "./dist/websocket.mjs",
+      "require": "./dist/websocket.js"
     }
   },
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 packages:
   - ./example
   - ./
+allowBuilds:
+  bufferutil: true
+  esbuild: true
+  unrs-resolver: true
+  utf-8-validate: true


### PR DESCRIPTION
`vrchat/websocket` was not defined as an export in package.json, so typescript hints refused to import it, and presumably could not be used at runtime

Also pnpm insists on adding allowBuilds when i install so thats here now